### PR TITLE
Created "Recommended content" page

### DIFF
--- a/recommended-content.md
+++ b/recommended-content.md
@@ -1,0 +1,24 @@
+---
+title: Recommended content
+description: 
+published: true
+date: 2022-05-20T11:45:52.918Z
+tags: 
+editor: markdown
+dateCreated: 2022-05-20T11:42:48.572Z
+---
+
+All Internet-Drafts should contain the following sections, depending on need:
+* [Privacy Consideration](#privacy-considerations)
+* [Implementation Status](#implementation-status)
+
+
+# Privacy Considerations
+Some Internet-Drafts have direct implications for personal privacy. In such cases, a "Privacy Considerations" section is recommended by RFC 6973, which offers guidance for developing privacy considerations for inclusion in protocol specifications. It aims to make designers, implementers, and users of Internet protocols aware of privacy-related design choices.
+
+# Implementation Status
+When an Internet-Draft is being considered for the standards track, the availability of one or more implementations, and any results of interoperability testing, are important matters. For this reason, an "Implementation Status" section is useful, as described by BCP 205.
+
+This will allow reviewers and working groups to assign due consideration to documents that have the benefit of running code, which may serve as evidence of valuable experimentation and feedback that have made the implemented protocols more mature.
+
+Since implementation information is necessarily time dependent, it is inappropriate for inclusion in a published RFC. The authors should include a note to the RFC Editor requesting that the section be removed before publication.


### PR DESCRIPTION
This is from Brian Carpenter's suggestion https://mailarchive.ietf.org/arch/msg/tools-discuss/MB0AavcLU-PfdXpwSETOzE8ZSCg/
After discussion with the AD's who look at these things, it was agreed to create this as a "Recommended content" page.  NOTE: links to RFCs and BCPs are automatically generated in the wiki and do not need to be added here.