### PR TITLE
reference anchors can't start with a number

### DIFF
--- a/rfcxml-vocabulary.md
+++ b/rfcxml-vocabulary.md
@@ -1538,7 +1538,7 @@ Allowed content: [**\<stream\>**](/rfcxml-vocabulary#stream)?, [**\<front\>**](/
 
 ### Attributes
 #### anchor (Required)
-Document-wide unique identifier for this element. Note that the value of the anchor element cannot start with a number. Usually, the value will be used both to label the reference in the References section and as an identifier in links to this reference entry; but see [**\<displayreference\>**](/rfcxml-vocabulary#displayreference) for how to change this.
+Document-wide unique identifier for this element. This will be used both to label the reference in the References section and as an identifier in links to this reference entry; but this can be changed as explained in [**\<displayreference\>**](/rfcxml-vocabulary#displayreference). When used in links, this identifier cannot start with a number.
 
 #### quote-title
 Specifies whether or not the title in the reference should be quoted. This can be used to prevent quoting, such as on errata.


### PR DESCRIPTION
noted this in the description of the anchor attribute of the reference element