### PR TITLE
fix: link cleanup for old materials on rfc-editor.org

### DIFF
--- a/diagrams.md
+++ b/diagrams.md
@@ -101,12 +101,12 @@ Another nice feature of Inkscape is that its 'Resize page to content' lets you r
 #### Nevil Brownlee, July 2018
 This is good if you're used to LibreOffice, and your drawing is fairly simple.
 
-Create your drawing using Draw, group it into a single object, then export it. (For me, that makes an SVG diagram that emacs and Inkscape display properly, but Firefox donesn't - however, check-svg.py's rewritten SVG diagram displays properly in Firefox, with Draw's arrowheads displayed properly.)
+Create your drawing using Draw, group it into a single object, then export it. (For me, that makes an SVG diagram that emacs and Inkscape display properly, but Firefox doesn't - however, check-svg.py's rewritten SVG diagram displays properly in Firefox, with Draw's arrowheads displayed properly.)
 
-## Powerpoint
+## PowerPoint
 ## {.tabset}
 ### Details
-Powerpoint is a commercial presentation tools with basic digramming capabilities, part of the MS Office suite. 
+PowerPoint is a commercial presentation tools with basic diagramming capabilities, part of the MS Office suite. 
 
 ### Community tips
 #### Don Fedyk, April 2021
@@ -191,7 +191,7 @@ Adjusted for 1/2 page it might look like this:
   viewBox="0 15 210 110"  
 ```
 
-Note that the x dimension is unchanged; also, in my experience, the scaling is far from linear. A slightly large diagram needed these values but the difference from 50 to 30 on the veiwBox height was hardly noticeable.
+Note that the x dimension is unchanged; also, in my experience, the scaling is far from linear. A slightly large diagram needed these values but the difference from 50 to 30 on the viewBox height was hardly noticeable.
 ```
 
   width="210mm"

--- a/diagrams.md
+++ b/diagrams.md
@@ -242,7 +242,7 @@ The [Author Tools](https://author-tools.ietf.org) web service can validate your 
 [RFC 8899](https://www.rfc-editor.org/rfc/rfc8899.html#figure-1) (Figures 1 - 5)
 [RFC 8989](https://www.rfc-editor.org/rfc/rfc8989.html#figure-1) (Figures 1 - 4)
 
-Some extracted SVG diagrams are also [available](https://www.rfc-editor.org/materials/format/svg/)
+For more examples of SVG diagrams used in RFCs, see [this list](https://rpc-wiki.rfc-editor.org/doku.php?id=v3_feature_usage).
 ## ASCII-art and SVG in a single \<artset\>
 The following example has one [**\<artset\>**](https://authors.ietf.org/en/rfcxml-vocabulary#artset) element that contains two [**\<artwork\>**](https://authors.ietf.org/en/rfcxml-vocabulary#artwork) elements, each of a different type. The SVG is included directly and a **name** attribute provided to recommend a filename if the diagram is extracted.
 ```xml

--- a/drafting-in-other-markup-languages.md
+++ b/drafting-in-other-markup-languages.md
@@ -27,13 +27,13 @@ Most of these toolchains are not widely used and in some cases rely on tools tha
 lyx2rfc is unmaintained and was last updated in 2014.
 
 # nroff format
-nroff is a text formatting program that produces output suitable for fixed-width files. An out of date [Nroff template](https://www.rfc-editor.org/materials/3-nroff.template) is available with a similarly out of date [tutorial](https://www.rfc-editor.org/materials/nroff.html).
+nroff is a text formatting program that produces output suitable for fixed-width files. 
   
 ## Emacs editor in nroff mode
 The popular open source editor Emacs includes [Nroff mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Nroff-Mode.html).
 
 ## nroff with Nroff Edit
-[nroff Edit](https://aaa-sec.com/nroffedit/) is a Java based WYSIWYG editor for writing and editing Internet-Drafts in nroff. The nroff based Internet-Draft file is edited in the left window while the resulting compiled text version is instantly shown in the right Window as a result of any edit changes.
+[nroff Edit](https://aaa-sec.com/nroffedit/) is a Java-based WYSIWYG editor for writing and editing Internet-Drafts in nroff. The nroff based Internet-Draft file is edited in the left window while the resulting compiled text version is instantly shown in the right window as a result of any edit changes. For an nroff template (without the whole application), there's an [empty I-D template](http://aaa-sec.com/pub/NroffEdit/empty.nroff) available.
 
 Nroff Edit is unmaintained and was last updated in 2015.
 

--- a/language-and-style.md
+++ b/language-and-style.md
@@ -12,7 +12,7 @@ dateCreated: 2021-12-14T23:52:28.098Z
 The recommended style for Internet-Drafts is documented in a collection of documents that are together known as the [RFC Editor's Style Guide](https://www.rfc-editor.org/styleguide/). This style guidance is not enforced while your document is an Internet-Draft, but will be if it becomes an RFC. A mature Internet-Draft may receive feedback to follow more of this guidance so that it is better prepared for the final RFC editing process.
 
 # Abbreviations
-Abbreviations should generally be expanded in parentheses.  The RFC Editor maintains a list of [approved abbreviations](https://www.rfc-editor.org/materials/abbrev.expansion.txt) that do not need to be expanded.
+Abbreviations should generally be expanded in parentheses.  The RFC Production Center maintains a list of [approved abbreviations](https://rpc-wiki.rfc-editor.org/rpc/wiki/doku.php?id=abbrev_list) that do not need to be expanded.
 
 # Internet-Drafts are not RFCs
 There are some key rules for I-D authors:

--- a/rfcxml-vocabulary.md
+++ b/rfcxml-vocabulary.md
@@ -1974,7 +1974,7 @@ Specifies the type of the source code. The value of this attribute is free text 
 
 Most of the preferred values for [**\<sourcecode\>**](/rfcxml-vocabulary#sourcecode) types are language names, in a wide sense, such as "abnf", "asn.1", "bash", "c++", etc.
 
-A list of the preferred values is maintained on the RFC Editor web site at [https://www.rfc-editor.org/materials/sourcecode-types.txt](https://www.rfc-editor.org/materials/sourcecode-types.txt), and that list is updated over time. Thus, a consumer of RFCXML should not cause a failure when it encounters an unexpected type or no type is specified.
+A [list of the preferred values](https://rpc-wiki.rfc-editor.org/rpc/wiki/doku.php?id=sourcecode-types) is maintained by the RFC Production Center, and that list is updated over time. Thus, a consumer of RFCXML should not cause a failure when it encounters an unexpected type or no type is specified.
 ### Examples
 The following is a basic example of a c program as set by the **type** attribute, using a CDATA block because the source code contains angle brackets, and a **name** attribute that suggests a file name for the extracted code:
 ```xml


### PR DESCRIPTION
fixes #134 